### PR TITLE
fix: robust notification handling (issue #4)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,8 +14,12 @@ rules:
 # Optional: set a default watch folder (used if no folder argument is given)
 # watch_folder: "/Users/yourname/Downloads"
 
-# Suppress desktop notifications globally
+# Suppress desktop notifications globally (same effect as CLI --silent)
 # silent: false
+
+# Desktop notifications on successful moves (default: true). Set false to disable
+# without using silent: true (handy if you only want to mute notifications).
+# notifications: true
 
 # Always run in dry-run mode (safe preview, never moves files)
 # dry_run: false

--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG_PATH = Path.home() / ".config" / "smart-file-organizer" / "config.yaml"
 LOCAL_CONFIG_PATH = Path("config.yaml")
 
-VALID_KEYS = {"rules", "watch_folder", "silent", "dry_run"}
+VALID_KEYS = {"rules", "watch_folder", "silent", "dry_run", "notifications"}
 
 
 def load_config(config_path: str = None) -> dict:
@@ -66,3 +66,6 @@ def _validate(config: dict, path: Path):
             logger.warning(f"Config rule key '{ext}' should start with '.' (e.g. '.mp4')")
         if not isinstance(folder, str):
             raise ValueError(f"Rule value for '{ext}' must be a string folder name")
+
+    if "notifications" in config and not isinstance(config["notifications"], bool):
+        raise ValueError(f"'notifications' must be true or false in {path}")

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -43,4 +43,4 @@ def notify(title: str, message: str, timeout: int = 5):
         )
     except Exception as e:
         # Notifications are non-critical — never crash the main process
-        logger.debug(f"Notification failed: {e}")
+        logger.warning("Desktop notification failed (%s): %s", type(e).__name__, e)

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -21,8 +21,10 @@ LOG_FILE = "organizer_log.json"
 class Organizer:
     def __init__(self, watch_folder: Path, config_path: str = None, silent: bool = False):
         self.watch_folder = Path(watch_folder).resolve()
-        self.silent = silent
         self.config = load_config(config_path)
+        cfg_silent = bool(self.config.get("silent", False))
+        cfg_notify_off = self.config.get("notifications") is False
+        self.silent = silent or cfg_silent or cfg_notify_off
         self.custom_rules = self.config.get("rules", {})
         self.log_path = self.watch_folder / LOG_FILE
 
@@ -108,10 +110,17 @@ class Organizer:
         logger.info(f"Moved '{file_path.name}' → {subfolder}/")
 
         if not self.silent:
-            notify(
-                title="File Organizer",
-                message=f"Moved {file_path.name} → {subfolder}/",
-            )
+            try:
+                notify(
+                    title="File Organizer",
+                    message=f"Moved {file_path.name} → {subfolder}/",
+                )
+            except Exception as e:
+                logger.warning(
+                    "Unexpected error from notify() (%s): %s",
+                    type(e).__name__,
+                    e,
+                )
 
         print(f"  Moved: {file_path.name!r}  →  {subfolder}/")
         return entry

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -130,6 +130,36 @@ class TestUndo:
         assert (tmp_folder / "b.jpg").exists()
 
 
+class TestNotifications:
+    def test_organize_continues_when_notify_raises(self, tmp_folder):
+        cfg = tmp_folder / "cfg.yaml"
+        cfg.write_text("notifications: true\n")
+        org = Organizer(tmp_folder, config_path=str(cfg), silent=False)
+        f = make_file(tmp_folder, "photo.jpg")
+        with patch("src.organizer.notify", side_effect=RuntimeError("notify boom")):
+            entry = org.organize_file(f)
+        assert entry is not None
+        assert (tmp_folder / "Images" / "photo.jpg").exists()
+
+    def test_config_notifications_false_skips_notify(self, tmp_folder):
+        cfg = tmp_folder / "cfg.yaml"
+        cfg.write_text("notifications: false\n")
+        org = Organizer(tmp_folder, config_path=str(cfg), silent=False)
+        f = make_file(tmp_folder, "photo.jpg")
+        with patch("src.organizer.notify") as mock_notify:
+            org.organize_file(f)
+        mock_notify.assert_not_called()
+
+    def test_config_silent_skips_notify(self, tmp_folder):
+        cfg = tmp_folder / "cfg.yaml"
+        cfg.write_text("silent: true\n")
+        org = Organizer(tmp_folder, config_path=str(cfg), silent=False)
+        f = make_file(tmp_folder, "photo.jpg")
+        with patch("src.organizer.notify") as mock_notify:
+            org.organize_file(f)
+        mock_notify.assert_not_called()
+
+
 class TestReport:
     def test_report_empty(self, organizer):
         r = organizer.report()


### PR DESCRIPTION
- Honor config silent and new notifications flag in Organizer
- Log notification failures at WARNING in notifier and at call site
- Wrap notify() in try/except so unexpected errors never abort moves
- Document notifications toggle in config.yaml
- Add tests for failure isolation and config-driven suppression