### PR TITLE
Add timestamped organizer.log audit trail (issue #17)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,8 @@ rules: {}
 
 # Always run in dry-run mode (safe preview, never moves files)
 # dry_run: false
+
+# Human-readable move audit log (default: organizer.log in the watch folder).
+# Relative paths are resolved against the watch folder; absolute paths are allowed.
+# organizer_log: "organizer.log"
+# organizer_log: "logs/organizer.log"

--- a/organizer/logger.py
+++ b/organizer/logger.py
@@ -1,0 +1,48 @@
+"""Human-readable timestamped audit log for file moves (organizer.log)."""
+
+from datetime import datetime
+from pathlib import Path
+
+_DEFAULT_LOG_NAME = "organizer.log"
+
+
+def resolve_audit_log_path(watch_folder: Path, config: dict) -> Path:
+    """
+    Resolve the audit log path from config.
+
+    If ``organizer_log`` is unset, defaults to ``<watch_folder>/organizer.log``.
+    Relative paths are resolved against ``watch_folder``; absolute paths are used as-is.
+    """
+    watch_folder = Path(watch_folder).resolve()
+    raw = config.get("organizer_log")
+    if raw is None or raw == "":
+        return watch_folder / _DEFAULT_LOG_NAME
+    path = Path(raw)
+    if path.is_absolute():
+        return path.resolve()
+    return (watch_folder / path).resolve()
+
+
+def format_moved_line(watch_folder: Path, source_file: Path, dest_file: Path) -> str:
+    """Build ``name → relative/dest`` detail for a MOVED line."""
+    watch_folder = Path(watch_folder).resolve()
+    dest_file = Path(dest_file).resolve()
+    try:
+        rel_dest = dest_file.relative_to(watch_folder).as_posix()
+    except ValueError:
+        rel_dest = dest_file.as_posix()
+    return f"{Path(source_file).name} → {rel_dest}"
+
+
+def append_audit_line(log_path: Path, kind: str, detail: str) -> None:
+    """
+    Append one line: ``[YYYY-MM-DD HH:MM:SS] KIND: detail``.
+
+    ``kind`` must be one of ``MOVED``, ``ERROR``, ``SKIP``.
+    """
+    log_path = Path(log_path)
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    line = f"[{ts}] {kind}: {detail}\n"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(line)

--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG_PATH = Path.home() / ".config" / "smart-file-organizer" / "config.yaml"
 LOCAL_CONFIG_PATH = Path("config.yaml")
 
-VALID_KEYS = {"rules", "watch_folder", "silent", "dry_run", "notifications"}
+VALID_KEYS = {
+    "rules",
+    "watch_folder",
+    "silent",
+    "dry_run",
+    "notifications",
+    "organizer_log",
+}
 
 
 def load_config(config_path: str = None) -> dict:
@@ -110,3 +117,7 @@ def validate_config(config: dict, path: Path):
     notifications = config.get("notifications")
     if notifications is not None and not isinstance(notifications, bool):
         raise ValueError(f"'notifications' must be a boolean in {path}")
+
+    organizer_log = config.get("organizer_log")
+    if organizer_log is not None and not isinstance(organizer_log, str):
+        raise ValueError(f"'organizer_log' must be a string path in {path}")

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from . import categorizer
 from .config import load_config
 from .notifier import notify
+from organizer.logger import (
+    append_audit_line,
+    format_moved_line,
+    resolve_audit_log_path,
+)
 from organizer.undo import (
     HISTORY_FILE,
     load_run_snapshot,
@@ -36,6 +41,13 @@ class Organizer:
         self.silent = silent or cfg_silent or cfg_notify_off
         self.custom_rules = self.config.get("rules", {})
         self.log_path = self.watch_folder / LOG_FILE
+        self.audit_log_path = resolve_audit_log_path(self.watch_folder, self.config)
+
+    def _write_audit(self, kind: str, detail: str) -> None:
+        try:
+            append_audit_line(self.audit_log_path, kind, detail)
+        except OSError as e:
+            logger.warning("Could not append audit log (%s): %s", kind, e)
 
     # ---------------- LOG HANDLING ----------------
 
@@ -85,13 +97,20 @@ class Organizer:
             file_path.relative_to(self.watch_folder)
         except ValueError:
             logger.warning(f"Refusing to move file outside watch folder: {file_path}")
+            self._write_audit("SKIP", f"outside watch folder: {file_path}")
             return None
 
         if not file_path.exists():
             logger.warning(f"File no longer exists: {file_path}")
+            self._write_audit("SKIP", f"missing: {file_path.name}")
+            return None
+
+        if file_path.resolve() == self.audit_log_path.resolve():
+            self._write_audit("SKIP", f"protected file: {file_path.name}")
             return None
 
         if file_path.name in (LOG_FILE, HISTORY_FILE):
+            self._write_audit("SKIP", f"internal file: {file_path.name}")
             return None
 
         subfolder = categorizer.categorize(file_path, self.custom_rules)
@@ -131,9 +150,17 @@ class Organizer:
                     logger.error(
                         f"Failed to move '{file_path.name}' after {max_retries} attempts: {e}"
                     )
+                    self._write_audit(
+                        "ERROR",
+                        f"failed to move {file_path.name!r} after {max_retries} attempts: {e}",
+                    )
                     raise
 
         # Log success
+        self._write_audit(
+            "MOVED",
+            format_moved_line(self.watch_folder, file_path, dest_file),
+        )
         self._append_log(entry)
         logger.info(f"Moved '{file_path.name}' → {subfolder}/")
 
@@ -156,8 +183,11 @@ class Organizer:
         results = []
 
         files = [
-            f for f in self.watch_folder.iterdir()
-            if f.is_file() and f.name not in (LOG_FILE, HISTORY_FILE)
+            f
+            for f in self.watch_folder.iterdir()
+            if f.is_file()
+            and f.name not in (LOG_FILE, HISTORY_FILE)
+            and f.resolve() != self.audit_log_path.resolve()
         ]
 
         if not files:

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -3,6 +3,7 @@ test_organizer.py - Unit tests for the Organizer class.
 """
 
 import json
+import re
 import pytest
 import shutil
 from pathlib import Path
@@ -235,3 +236,63 @@ class TestReport:
         assert r["total"] == 3
         assert r["categories"]["Images"]["count"] == 2
         assert r["categories"]["Videos"]["count"] == 1
+
+
+MOVED_LINE = re.compile(
+    r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] MOVED: .+ → .+\n?$",
+    re.MULTILINE,
+)
+
+
+class TestAuditLog:
+    def test_moved_line_written_to_default_organizer_log(self, organizer, tmp_folder):
+        f = make_file(tmp_folder, "report.pdf")
+        with patch("src.organizer.notify"), \
+             patch("src.categorizer._extract_pdf_text", return_value=""):
+            organizer.organize_file(f)
+        audit = tmp_folder / "organizer.log"
+        assert audit.exists()
+        text = audit.read_text(encoding="utf-8")
+        assert "MOVED:" in text
+        assert "report.pdf" in text
+        assert "→" in text
+        assert MOVED_LINE.search(text)
+
+    def test_custom_audit_log_path_from_config(self, tmp_folder):
+        custom = tmp_folder / "logs" / "my-audit.log"
+        cfg = tmp_folder / "cfg.yaml"
+        cfg.write_text('organizer_log: "logs/my-audit.log"\n')
+        org = Organizer(tmp_folder, config_path=str(cfg), silent=True)
+        f = make_file(tmp_folder, "photo.jpg")
+        with patch("src.organizer.notify"):
+            org.organize_file(f)
+        assert custom.exists()
+        assert "MOVED:" in custom.read_text(encoding="utf-8")
+
+    def test_skip_outside_watch_folder_is_audited(self, organizer, tmp_path):
+        outside = tmp_path / "nope.jpg"
+        outside.write_text("x")
+        organizer.organize_file(outside)
+        audit = organizer.watch_folder / "organizer.log"
+        text = audit.read_text(encoding="utf-8")
+        assert "SKIP:" in text
+        assert "outside watch folder" in text
+
+    def test_skip_internal_json_log(self, organizer, tmp_folder):
+        log = make_file(tmp_folder, "organizer_log.json", "{}")
+        organizer.organize_file(log)
+        audit = tmp_folder / "organizer.log"
+        assert "SKIP:" in audit.read_text(encoding="utf-8")
+        assert "internal file" in audit.read_text(encoding="utf-8")
+
+    def test_error_logged_when_move_exhausts_retries(self, organizer, tmp_folder):
+        f = make_file(tmp_folder, "photo.jpg")
+        with patch("src.organizer.time.sleep"), \
+             patch("src.organizer.notify"), \
+             patch("src.organizer.shutil.move", side_effect=OSError("locked")):
+            with pytest.raises(OSError):
+                organizer.organize_file(f)
+        audit = tmp_folder / "organizer.log"
+        body = audit.read_text(encoding="utf-8")
+        assert "ERROR:" in body
+        assert "photo.jpg" in body


### PR DESCRIPTION
Introduce organizer/logger.py to append [YYYY-MM-DD HH:MM:SS] MOVED, ERROR, and SKIP lines. Log path is configurable via organizer_log in config.yaml (default: organizer.log in the watch folder). Wire logging into organize_file and exclude the audit file from bulk organization.