### PR TITLE
feat: add run summary desktop notifications (fixes #20)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,9 +13,9 @@ rules: {}
 # Suppress desktop notifications globally (same effect as CLI --silent)
 # silent: false
 
-# Desktop notifications on successful moves (default: true). Set false to disable
-# without using silent: true (handy if you only want to mute notifications).
-# notifications: true
+# Desktop notifications (default: true). Set false to disable without using
+# silent: true (handy if you only want to mute notifications).
+# notify: true
 
 # Always run in dry-run mode (safe preview, never moves files)
 # dry_run: false

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ VALID_KEYS = {
     "silent",
     "dry_run",
     "notify",
+    "notifications",
     "log_file",
     "organizer_log",
 }
@@ -114,6 +115,10 @@ def validate_config(config: dict, path: Path):
     notify = config.get("notify")
     if notify is not None and not isinstance(notify, bool):
         raise ValueError(f"'notify' must be a boolean in {path}")
+
+    notifications = config.get("notifications")
+    if notifications is not None and not isinstance(notifications, bool):
+        raise ValueError(f"'notifications' must be a boolean in {path}")
 
     log_file = config.get("log_file")
     if log_file is not None and not isinstance(log_file, str):

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -36,11 +36,17 @@ class Organizer:
         cfg_folder = self.config.get("watch_folder")
         self.watch_folder = Path(cfg_folder or watch_folder).resolve()
 
-        # ✅ Correct notify key
         cfg_silent = bool(self.config.get("silent", False))
-        cfg_notify_off = self.config.get("notify") is False
+        cfg_notify = self.config.get("notify")
+        cfg_notifications = self.config.get("notifications")
+        if isinstance(cfg_notify, bool):
+            self.notifications_enabled = cfg_notify
+        elif isinstance(cfg_notifications, bool):
+            self.notifications_enabled = cfg_notifications
+        else:
+            self.notifications_enabled = True
 
-        self.silent = silent or cfg_silent or cfg_notify_off
+        self.silent = silent or cfg_silent or not self.notifications_enabled
         self.custom_rules = self.config.get("rules", {})
 
         # ✅ Use log_file from config
@@ -98,7 +104,12 @@ class Organizer:
 
     # ---------------- MAIN FILE ORGANIZATION ----------------
 
-    def organize_file(self, file_path: Path, dry_run: bool = False) -> dict | None:
+    def organize_file(
+        self,
+        file_path: Path,
+        dry_run: bool = False,
+        notify_on_success: bool = True,
+    ) -> dict | None:
         file_path = Path(file_path).resolve()
 
         # Safety check
@@ -175,8 +186,7 @@ class Organizer:
         self._append_log(entry)
         logger.info(f"Moved '{file_path.name}' → {subfolder}/")
 
-        # Notification
-        if not self.silent:
+        if notify_on_success and not self.silent:
             try:
                 notify(
                     title="File Organizer",
@@ -187,10 +197,6 @@ class Organizer:
 
         print(f"  Moved: {file_path.name!r}  →  {subfolder}/")
         return entry
-
-    # ---------------- ORGANIZE ALL ----------------
-
-    # ---------------- ORGANIZE ALL ----------------
 
     def organize_all(self, dry_run: bool = False) -> list:
         results = []
@@ -213,18 +219,35 @@ class Organizer:
             print("  No files to organize.")
             return results
 
-        if dry_run:
-           print(f"\n  Preview: {len(results)} file(s) would be moved.")
-        else:
-           print(f"\n  Done. {len(results)} file(s) moved.")
-
         for f in sorted(files):
-            entry = self.organize_file(f, dry_run=dry_run)
+            entry = self.organize_file(
+                f,
+                dry_run=dry_run,
+                notify_on_success=False,
+            )
             if entry:
                 results.append(entry)
 
-        print(f"\n  Done. {len(results)} file(s) moved.")
         save_run_snapshot(self.watch_folder, results, dry_run=dry_run)
+
+        if not dry_run and results and not self.silent:
+            category_count = len({entry["category"] for entry in results})
+            try:
+                notify(
+                    title="Smart File Organizer",
+                    message=f"Moved {len(results)} files across {category_count} categories",
+                )
+            except Exception as e:
+                logger.warning(
+                    "Unexpected error from notify() (%s): %s",
+                    type(e).__name__,
+                    e,
+                )
+
+        if not dry_run:
+            print(f"\n  Done. {len(results)} file(s) moved.")
+        else:
+            print(f"\n  Dry run complete. {len(results)} file(s) would be moved.")
         return results
 
     # ---------------- UNDO ----------------

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -117,11 +117,14 @@ class TestOrganizeFile:
 
 
 class TestOrganizeAll:
-    def test_organizes_multiple_files(self, organizer, tmp_folder):
+    def test_organizes_multiple_files(self, tmp_folder):
+        cfg = tmp_folder.parent / "cfg.yaml"
+        cfg.write_text("notify: true\n")
+        organizer = Organizer(tmp_folder, config_path=str(cfg), silent=False)
         make_file(tmp_folder, "a.jpg")
         make_file(tmp_folder, "b.mp4")
         make_file(tmp_folder, "c.zip")
-        with patch("src.organizer.notify"):
+        with patch("src.organizer.notify") as mock_notify:
             results = organizer.organize_all()
         assert len(results) == 3
         assert (tmp_folder / HISTORY_FILE).exists()
@@ -129,6 +132,10 @@ class TestOrganizeAll:
         assert set(snap.keys()) == {"a.jpg", "b.mp4", "c.zip"}
         for name in snap:
             assert "from" in snap[name] and "to" in snap[name]
+        mock_notify.assert_called_once_with(
+            title="Smart File Organizer",
+            message="Moved 3 files across 3 categories",
+        )
 
     def test_empty_folder_returns_empty(self, organizer, tmp_folder):
         results = organizer.organize_all()
@@ -206,6 +213,15 @@ class TestNotifications:
     def test_config_notifications_false_skips_notify(self, tmp_folder):
         cfg = tmp_folder / "cfg.yaml"
         cfg.write_text("notifications: false\n")
+        org = Organizer(tmp_folder, config_path=str(cfg), silent=False)
+        f = make_file(tmp_folder, "photo.jpg")
+        with patch("src.organizer.notify") as mock_notify:
+            org.organize_file(f)
+        mock_notify.assert_not_called()
+
+    def test_config_notify_false_skips_notify(self, tmp_folder):
+        cfg = tmp_folder / "cfg.yaml"
+        cfg.write_text("notify: false\n")
         org = Organizer(tmp_folder, config_path=str(cfg), silent=False)
         f = make_file(tmp_folder, "photo.jpg")
         with patch("src.organizer.notify") as mock_notify:


### PR DESCRIPTION
## Summary
Implements issue #20 by adding a **single post-run desktop notification** after `organize_all()` completes, using cross-platform `plyer` notifications.

### What’s included
- Sends notification with:
  - **Title:** `Smart File Organizer`
  - **Body:** `Moved X files across Y categories`
- Fires only when notifications are enabled via config:
  - Supports `notify: true/false` (primary key for #20)
  - Keeps backward compatibility with `notifications: true/false`
- Preserves existing `--silent` behavior to suppress notifications.

### Acceptance Criteria Mapping
- **Retry not required for this issue**; focus is notification behavior.
- ✅ Desktop notification sent after organize run  
- ✅ No need to inspect terminal to confirm results  
- ✅ Uses `plyer` for cross-platform compatibility (Windows/macOS)  
- ✅ Notification controlled by config flag (`notify`)  

### Test Plan
- Ran: `python -m pytest tests/test_organizer.py tests/test_integration.py`
- Result: **35 passed**
- Added/updated tests to verify:
  - Summary notification fires once per run with correct message
  - `notify: false` disables notifications
  - Existing organize and snapshot behavior remains stable