### PR TITLE
feat: export report to CSV with --export (issue #19)

### DIFF
--- a/organizer/reporter.py
+++ b/organizer/reporter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import csv
 import re
+from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -102,3 +104,22 @@ def build_audit_summary(audit_log_path: Path) -> dict[str, Any]:
     except OSError:
         return summarize_moves([])
     return summarize_moves(parse_audit_log_text(text))
+
+
+def export_report_to_csv(report: dict[str, Any], dest_dir: Path | None = None) -> Path:
+    """
+    Write the category summary to ``organizer_report_YYYYMMDD.csv`` under ``dest_dir``.
+
+    When ``dest_dir`` is None, uses the process current working directory.
+    """
+    out_dir = Path(dest_dir) if dest_dir is not None else Path.cwd()
+    out_dir = out_dir.resolve()
+    name = f"organizer_report_{datetime.now().strftime('%Y%m%d')}.csv"
+    path = (out_dir / name).resolve()
+    categories = report.get("categories") or {}
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["category", "count", "last_activity"])
+        for cat, info in categories.items():
+            w.writerow([cat, info["count"], info["last_activity"]])
+    return path

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,7 +6,7 @@ Commands:
   organizer watch <folder>   Watch a folder in real-time
   organizer run <folder>     Organize all files in a folder once
   organizer undo <folder>    Undo the last run session (or log steps if no snapshot)
-  organizer report <folder>  Show an organization summary report
+  organizer report <folder>  Show an organization summary report (--export saves CSV)
 """
 
 import sys
@@ -18,7 +18,7 @@ from rich import print
 from rich.box import ASCII
 from rich.table import Table
 
-from organizer.reporter import build_audit_summary
+from organizer.reporter import build_audit_summary, export_report_to_csv
 
 # Allow running as: python -m src.cli OR as installed command
 try:
@@ -122,7 +122,14 @@ def cmd_report(args):
 
     if args.json:
         print(json.dumps(report, indent=2))
+        if args.export:
+            out = export_report_to_csv(report, Path.cwd())
+            print(f"\n[green]Report saved to {out}[/green]")
         return
+
+    if args.export:
+        out = export_report_to_csv(report, Path.cwd())
+        print(f"[green]Report saved to {out}[/green]\n")
 
     print("\n[bold cyan]Smart File Organizer - Report[/bold cyan]")
     print("-" * 40)
@@ -214,6 +221,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show an organization summary report",
     )
     p_report.add_argument("--json", action="store_true", help="Output report as JSON")
+    p_report.add_argument(
+        "--export",
+        action="store_true",
+        help="Write category summary to organizer_report_YYYYMMDD.csv in the current directory",
+    )
     p_report.set_defaults(func=cmd_report)
 
     return parser

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -248,6 +248,41 @@ class TestReporter:
         assert s["total"] == 0
         assert s["categories"] == {}
 
+    def test_export_report_to_csv(self, tmp_path):
+        import csv
+
+        from organizer.reporter import export_report_to_csv
+
+        report = {
+            "total": 2,
+            "categories": {
+                "Images": {"count": 2, "last_activity": "2026-04-18"},
+            },
+            "first_activity": "2026-04-17",
+            "last_activity": "2026-04-18",
+        }
+        path = export_report_to_csv(report, dest_dir=tmp_path)
+        assert path.parent == tmp_path.resolve()
+        assert path.name.startswith("organizer_report_")
+        assert path.suffix == ".csv"
+        rows = list(path.read_text(encoding="utf-8").strip().splitlines())
+        parsed = list(csv.reader(rows))
+        assert parsed[0] == ["category", "count", "last_activity"]
+        assert parsed[1] == ["Images", "2", "2026-04-18"]
+
+    def test_export_empty_report_writes_header_only(self, tmp_path):
+        import csv
+
+        from organizer.reporter import export_report_to_csv
+
+        path = export_report_to_csv(
+            {"total": 0, "categories": {}, "first_activity": None, "last_activity": None},
+            dest_dir=tmp_path,
+        )
+        lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        assert len(lines) == 1
+        assert list(csv.reader(lines)) == [["category", "count", "last_activity"]]
+
 
 class TestReport:
     def test_report_empty(self, organizer):


### PR DESCRIPTION
Add export_report_to_csv in organizer/reporter.py writing category, count, and last_activity to organizer_report_YYYYMMDD.csv in the working directory.

Extend organizer report with --export; print confirmation with full path. CSV is written for empty reports (header only) and alongside --json when both flags are set.